### PR TITLE
create twistbackup path if not exist

### DIFF
--- a/twist
+++ b/twist
@@ -455,7 +455,7 @@ function installsslibev(){
         echo "/usr/lib" > /etc/ld.so.conf.d/lib.conf
     fi
     ldconfig
-    mbedver="$(wget -qO- https://tls.mbed.org/download-archive | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | cut -d'.' -f1,2,3 | sort -V | tail -1)"
+    mbedver="2.6.0"
     wget -t 3 -T 30 -nv -O mbedtls-${mbedver}-gpl.tgz https://tls.mbed.org/download/mbedtls-${mbedver}-gpl.tgz
     [ "$?" != "0" ] && { echo ""; echo -e "# [\033[31;1mCannot download mbed source. Aborting! \033[0m]"; echo ""; exit 1; }
     [ -d mbedtls-${mbedver} ] && rm -rf mbedtls-${mbedver}

--- a/twist
+++ b/twist
@@ -166,6 +166,7 @@ function uninstall_twist(){
     rm -fr /usr/local/share/doc/shadowsocks-libev
     rm -fr /etc/shadowsocks-libev
     rm -f /etc/init.d/shadowsocks
+    [ ! -d /etc/twistbackup ] && mkdir -p /etc/twistbackup
     [ -e /etc/twistbackup/sysctl.conf ] && { cp -f "/etc/twistbackup/sysctl.conf" "/etc/sysctl.conf"; sysctl -e -p; }
     [ -e /etc/twistbackup/limits.conf ] && cp -f "/etc/twistbackup/limits.conf" "/etc/security/limits.conf"
     [ -e /etc/twistbackup/login ] && cp -f "/etc/twistbackup/login" "/etc/pam.d/login"


### PR DESCRIPTION
When using, it reports:
cp: cannot create regular file '/etc/twistbackup/sysctl.conf': No such file or directory

So I fix it.