### PR TITLE
A better way to compare kernel version

### DIFF
--- a/twist
+++ b/twist
@@ -429,7 +429,7 @@ function dependenciesinstall(){
 function tcpbbrenable(){
     if [ "$BBR" = "enable" ]; then
         timemachine "backup" "/etc/sysctl.conf" "/etc/twist/sysctl.conf"
-        if [ $(echo ${kernelverheader} | awk -v ver=4.8 '{print($1>ver)? "1":"0"}') -eq "1" ] || [ "$kernelupdated" = "true" ]; then
+        if [ "$(printf '%s\n' ${kernelverheader} "4.8" | sort -V | head -n1)" != ${kernelverheader} ] || [ "$kernelupdated" = "true" ]; then
             if [ ! "$(sysctl net.ipv4.tcp_available_congestion_control | awk '{print $3}')" = "bbr" ]; then
                 sed -i '/net.ipv4.tcp_congestion_control/d' /etc/sysctl.conf
                 echo "net.ipv4.tcp_congestion_control = bbr" >> /etc/sysctl.conf


### PR DESCRIPTION
A better way to compare kernel version, like 4.10 < 4.8.