### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 ## Set Up your Shadowsocks-libev Server
 Please **Run Command** below on your server to **Install Twist**
 ```bash
-sudo wget https://raw.githubusercontent.com/Unbinilium/Twist/master/twist -O twist.sh && chmod -x twist.sh && bash twist.sh
+sudo wget https://raw.githubusercontent.com/Unbinilium/Twist/master/twist -O twist.sh && sudo chmod -x twist.sh && sudo bash twist.sh
 ```
 
 ## Attention


### PR DESCRIPTION
"sudo" is required for both "chmod -x twist.sh" and "bash twist.sh" to run as intended; on line 29.